### PR TITLE
add swfobject dependencies arg

### DIFF
--- a/src/js/core/engines/flashCore.coffee
+++ b/src/js/core/engines/flashCore.coffee
@@ -1,4 +1,4 @@
-do (root = this, factory = (cfg, utils, Timer, EngineCore) ->
+do (root = this, factory = (cfg, utils, Timer, EngineCore, swfobject) ->
     {EVENTS, STATES, ERRCODE} = cfg.engine
     timerResolution = cfg.timerResolution
 


### PR DESCRIPTION
https://github.com/amdjs/amdjs-api/blob/master/AMD.md#dependencies-
then the loader may choose to only call the factory with the number of arguments corresponding to the function's arity or length.
