### PR TITLE
remove ‘playing’  in passed states

### DIFF
--- a/src/js/player.coffee
+++ b/src/js/player.coffee
@@ -134,7 +134,7 @@ do (root = this, factory = (cfg, utils, Events, Playlist, Engine) ->
 
             pass = ->
                 self.getState() in [
-                    STATES.PLAYING, STATES.PAUSE, STATES.STOP, STATES.END
+                    STATES.PAUSE, STATES.STOP, STATES.END
                 ]
 
             @engine = engine.on(EVENTS.STATECHANGE, (e) ->


### PR DESCRIPTION
playing状态不应该被排除在卡断处理的状态之外。会导致卡断处理无法正常生效。
