### PR TITLE
支持.aac后缀名

### DIFF
--- a/src/js/core/engines/engine.coffee
+++ b/src/js/core/engines/engine.coffee
@@ -99,7 +99,7 @@ do (root = @, factory = (
                     .setMute(oldEngine.getMute())
 
         canPlayType: (type) ->
-            type = 'm4a' if type is 'mp4a'
+            type = 'm4a' if type is 'mp4a' or type is 'aac'
             $.inArray(type, @getSupportedTypes()) isnt -1
 
         getSupportedTypes: ->

--- a/src/js/core/engines/engineCore.coffee
+++ b/src/js/core/engines/engineCore.coffee
@@ -12,7 +12,7 @@ do (root = @, factory = (cfg, utils, Events) ->
             @_supportedTypes
 
         canPlayType: (type) ->
-            type = 'm4a' if type is 'mp4a'
+            type = 'm4a' if type is 'mp4a' or type is 'aac'
             $.inArray(type, @getSupportedTypes()) isnt -1
 
         reset: ->


### PR DESCRIPTION
用aac编码的文件可能使用  aac,m4a,mp4a 的文件名后缀。aac也需转换为m4a 用作canPlayType 测试
